### PR TITLE
Rename `FZF_HISTDB_FORCE_DATE_FORMAT` to `HISTDB_FZF_FORCE_DATE_FORMAT`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Configuration
 -------------
 
 - Date format: By default, the date format (`us` or `non-us`) is auto-detected based on your current locale settings
-  (see `LC_TIME`). You can override this by setting the environment variable `FZF_HISTDB_FORCE_DATE_FORMAT` to either
+  (see `LC_TIME`). You can override this by setting the environment variable `HISTDB_FZF_FORCE_DATE_FORMAT` to either
   `us` or `non-us`.
 
 Logging

--- a/fzf-histdb.zsh
+++ b/fzf-histdb.zsh
@@ -11,7 +11,7 @@ fi
 get_date_format() (
     local date_format
 
-    date_format="$(awk '{ print tolower($1) }' <<< "${FZF_HISTDB_FORCE_DATE_FORMAT}")"
+    date_format="$(awk '{ print tolower($1) }' <<< "${HISTDB_FZF_FORCE_DATE_FORMAT}")"
 
     if [[ "${date_format}" != "us" && "${date_format}" != "non-us" ]]; then
         eval "$(locale)"


### PR DESCRIPTION
Use the prefix `HISTDB_FZF` to be consistent with other variable names.